### PR TITLE
add object core extension methods present? and blank?

### DIFF
--- a/opal/active_support/core_ext.rb
+++ b/opal/active_support/core_ext.rb
@@ -1,1 +1,2 @@
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/object'

--- a/opal/active_support/core_ext/object.rb
+++ b/opal/active_support/core_ext/object.rb
@@ -1,0 +1,100 @@
+# encoding: utf-8
+
+class Object
+  # An object is blank if it's false, empty, or a whitespace string.
+  # For example, '', '   ', +nil+, [], and {} are all blank.
+  #
+  # This simplifies:
+  #
+  #   if address.nil? || address.empty?
+  #
+  # ...to:
+  #
+  #   if address.blank?
+  def blank?
+    respond_to?(:empty?) ? empty? : !self
+  end
+
+  # An object is present if it's not <tt>blank?</tt>.
+  def present?
+    !blank?
+  end
+
+  # Returns object if it's <tt>present?</tt> otherwise returns +nil+.
+  # <tt>object.presence</tt> is equivalent to <tt>object.present? ? object : nil</tt>.
+  #
+  # This is handy for any representation of objects where blank is the same
+  # as not present at all. For example, this simplifies a common check for
+  # HTTP POST/query parameters:
+  #
+  #   state   = params[:state]   if params[:state].present?
+  #   country = params[:country] if params[:country].present?
+  #   region  = state || country || 'US'
+  #
+  # ...becomes:
+  #
+  #   region = params[:state].presence || params[:country].presence || 'US'
+  def presence
+    self if present?
+  end
+end
+
+class NilClass
+  # +nil+ is blank:
+  #
+  #   nil.blank? # => true
+  def blank?
+    true
+  end
+end
+
+class Boolean
+  # +false+ is blank:
+  #
+  #   false.blank? # => true
+  #
+  # +true+ is not blank:
+  #
+  #   true.blank? # => false
+  def blank?
+    self == false
+  end
+end
+
+class Array
+  # An array is blank if it's empty:
+  #
+  #   [].blank?      # => true
+  #   [1,2,3].blank? # => false
+  alias_method :blank?, :empty?
+end
+
+class Hash
+  # A hash is blank if it's empty:
+  #
+  #   {}.blank?                # => true
+  #   { key: 'value' }.blank?  # => false
+  alias_method :blank?, :empty?
+end
+
+class String
+  # A string is blank if it's empty or contains whitespaces only:
+  #
+  #   ''.blank?                 # => true
+  #   '   '.blank?              # => true
+  #   '　'.blank?               # => true
+  #   ' something here '.blank? # => false
+  def blank?
+    self !~ /[^\s]/
+  end
+end
+
+class Numeric #:nodoc:
+  # No number is blank:
+  #
+  #   1.blank? # => false
+  #   0.blank? # => false
+  def blank?
+    false
+  end
+end


### PR DESCRIPTION
This PR adds `blank?` and `present?` methods to `Object`.

The following values are considered to be blank:
- nil and false
- strings composed only of whitespace
- empty arrays and hashes
- any other object that responds to empty? and it is empty

Numbers, in particular 0 and 0.0 are not considered blank.
