### PR TITLE
String#truncate method

### DIFF
--- a/opal/active_support/core_ext/string/filters.rb
+++ b/opal/active_support/core_ext/string/filters.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+class String
+  # Returns the string, first removing all whitespace on both ends of
+  # the string, and then changing remaining consecutive whitespace
+  # groups into one space each.
+  #
+  # Note that it handles both ASCII and Unicode whitespace.
+  #
+  #   %{ Multi-line
+  #      string }.squish                   # => "Multi-line string"
+  #   " foo   bar    \n   \t   boo".squish # => "foo bar boo"
+  # def squish
+  #   dup.squish!
+  # end
+
+  # Performs a destructive squish. See String#squish.
+  #   str = " foo   bar    \n   \t   boo"
+  #   str.squish!                         # => "foo bar boo"
+  #   str                                 # => "foo bar boo"
+  # def squish!
+  #   gsub!(/[[:space:]]+/, " ")
+  #   strip!
+  #   self
+  # end
+
+  # Returns a new string with all occurrences of the patterns removed.
+  #   str = "foo bar test"
+  #   str.remove(" test")                 # => "foo bar"
+  #   str.remove(" test", /bar/)          # => "foo "
+  #   str                                 # => "foo bar test"
+  # def remove(*patterns)
+  #   dup.remove!(*patterns)
+  # end
+
+  # Alters the string by removing all occurrences of the patterns.
+  #   str = "foo bar test"
+  #   str.remove!(" test", /bar/)         # => "foo "
+  #   str                                 # => "foo "
+  # def remove!(*patterns)
+  #   patterns.each do |pattern|
+  #     gsub! pattern, ""
+  #   end
+  #
+  #   self
+  # end
+
+  # Truncates a given +text+ after a given <tt>length</tt> if +text+ is longer than <tt>length</tt>:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27)
+  #   # => "Once upon a time in a wo..."
+  #
+  # Pass a string or regexp <tt>:separator</tt> to truncate +text+ at a natural break:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: ' ')
+  #   # => "Once upon a time in a..."
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: /\s/)
+  #   # => "Once upon a time in a..."
+  #
+  # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "...")
+  # for a total length not exceeding <tt>length</tt>:
+  #
+  #   'And they found that many people were sleeping better.'.truncate(25, omission: '... (continued)')
+  #   # => "And they f... (continued)"
+  def truncate(truncate_at, options = {})
+    return dup unless length > truncate_at
+
+    omission = options[:omission] || "..."
+    length_with_room_for_omission = truncate_at - omission.length
+    stop = \
+      if options[:separator]
+                   rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+      else
+        length_with_room_for_omission
+      end
+
+    "#{self[0, stop]}#{omission}"
+  end
+
+  # Truncates +text+ to at most <tt>bytesize</tt> bytes in length without
+  # breaking string encoding by splitting multibyte characters or breaking
+  # grapheme clusters ("perceptual characters") by truncating at combining
+  # characters.
+  #
+  #   >> "🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪".size
+  #   => 20
+  #   >> "🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪".bytesize
+  #   => 80
+  #   >> "🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪🔪".truncate_bytes(20)
+  #   => "🔪🔪🔪🔪…"
+  #
+  # The truncated text ends with the <tt>:omission</tt> string, defaulting
+  # to "…", for a total length not exceeding <tt>bytesize</tt>.
+  # def truncate_bytes(truncate_at, omission: "…")
+  #   omission ||= ""
+  #
+  #   case
+  #   when bytesize <= truncate_at
+  #     dup
+  #   when omission.bytesize > truncate_at
+  #     raise ArgumentError, "Omission #{omission.inspect} is #{omission.bytesize}, larger than the truncation length of #{truncate_at} bytes"
+  #   when omission.bytesize == truncate_at
+  #     omission.dup
+  #   else
+  #     self.class.new.tap do |cut|
+  #       cut_at = truncate_at - omission.bytesize
+  #
+  #       scan(/\X/) do |grapheme|
+  #         if cut.bytesize + grapheme.bytesize <= cut_at
+  #           cut << grapheme
+  #         else
+  #           break
+  #         end
+  #       end
+  #
+  #       cut << omission
+  #     end
+  #   end
+  # end
+
+  # Truncates a given +text+ after a given number of words (<tt>words_count</tt>):
+  #
+  #   'Once upon a time in a world far far away'.truncate_words(4)
+  #   # => "Once upon a time..."
+  #
+  # Pass a string or regexp <tt>:separator</tt> to specify a different separator of words:
+  #
+  #   'Once<br>upon<br>a<br>time<br>in<br>a<br>world'.truncate_words(5, separator: '<br>')
+  #   # => "Once<br>upon<br>a<br>time<br>in..."
+  #
+  # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "..."):
+  #
+  #   'And they found that many people were sleeping better.'.truncate_words(5, omission: '... (continued)')
+  #   # => "And they found that many... (continued)"
+  # def truncate_words(words_count, options = {})
+  #   sep = options[:separator] || /\s+/
+  #   sep = Regexp.escape(sep.to_s) unless Regexp === sep
+  #   if self =~ /\A((?>.+?#{sep}){#{words_count - 1}}.+?)#{sep}.*/m
+  #     $1 + (options[:omission] || "...")
+  #   else
+  #     dup
+  #   end
+  # end
+end
+

--- a/test/core_ext/string_ext_test.rb
+++ b/test/core_ext/string_ext_test.rb
@@ -267,24 +267,86 @@ class StringInflectionsTest < ActiveSupport::TestCase
   #   assert_not_predicate "production".inquiry, :development?
   # end
 
-  # def test_truncate
-  #   assert_equal "Hello World!", "Hello World!".truncate(12)
-  #   assert_equal "Hello Wor...", "Hello World!!".truncate(12)
-  # end
+  def test_truncate
+    assert_equal "Hello World!", "Hello World!".truncate(12)
+    assert_equal "Hello Wor...", "Hello World!!".truncate(12)
+  end
 
-  # def test_truncate_with_omission_and_separator
-  #   assert_equal "Hello[...]", "Hello World!".truncate(10, omission: "[...]")
-  #   assert_equal "Hello[...]", "Hello Big World!".truncate(13, omission: "[...]", separator: " ")
-  #   assert_equal "Hello Big[...]", "Hello Big World!".truncate(14, omission: "[...]", separator: " ")
-  #   assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: " ")
-  # end
+  def test_truncate_with_omission_and_separator
+    assert_equal "Hello[...]", "Hello World!".truncate(10, omission: "[...]")
+    assert_equal "Hello[...]", "Hello Big World!".truncate(13, omission: "[...]", separator: " ")
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(14, omission: "[...]", separator: " ")
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: " ")
+  end
 
-  # def test_truncate_with_omission_and_regexp_separator
-  #   assert_equal "Hello[...]", "Hello Big World!".truncate(13, omission: "[...]", separator: /\s/)
-  #   assert_equal "Hello Big[...]", "Hello Big World!".truncate(14, omission: "[...]", separator: /\s/)
-  #   assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: /\s/)
-  # end
+  def test_truncate_with_omission_and_regexp_separator
+    assert_equal "Hello[...]", "Hello Big World!".truncate(13, omission: "[...]", separator: /\s/)
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(14, omission: "[...]", separator: /\s/)
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: /\s/)
+  end
 
+  # def test_truncate_bytes
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16)
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: nil)
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: " ")
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: "🖖")
+  #
+  #   assert_equal "👍👍👍…", "👍👍👍👍".truncate_bytes(15)
+  #   assert_equal "👍👍👍", "👍👍👍👍".truncate_bytes(15, omission: nil)
+  #   assert_equal "👍👍👍 ", "👍👍👍👍".truncate_bytes(15, omission: " ")
+  #   assert_equal "👍👍🖖", "👍👍👍👍".truncate_bytes(15, omission: "🖖")
+  #
+  #   assert_equal "…", "👍👍👍👍".truncate_bytes(5)
+  #   assert_equal "👍", "👍👍👍👍".truncate_bytes(5, omission: nil)
+  #   assert_equal "👍 ", "👍👍👍👍".truncate_bytes(5, omission: " ")
+  #   assert_equal "🖖", "👍👍👍👍".truncate_bytes(5, omission: "🖖")
+  #
+  #   assert_equal "…", "👍👍👍👍".truncate_bytes(4)
+  #   assert_equal "👍", "👍👍👍👍".truncate_bytes(4, omission: nil)
+  #   assert_equal " ", "👍👍👍👍".truncate_bytes(4, omission: " ")
+  #   assert_equal "🖖", "👍👍👍👍".truncate_bytes(4, omission: "🖖")
+  #
+  #   assert_raise ArgumentError do
+  #     "👍👍👍👍".truncate_bytes(3, omission: "🖖")
+  #   end
+  # end
+  #
+  # def test_truncate_bytes_preserves_codepoints
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16)
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: nil)
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: " ")
+  #   assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: "🖖")
+  #
+  #   assert_equal "👍👍👍…", "👍👍👍👍".truncate_bytes(15)
+  #   assert_equal "👍👍👍", "👍👍👍👍".truncate_bytes(15, omission: nil)
+  #   assert_equal "👍👍👍 ", "👍👍👍👍".truncate_bytes(15, omission: " ")
+  #   assert_equal "👍👍🖖", "👍👍👍👍".truncate_bytes(15, omission: "🖖")
+  #
+  #   assert_equal "…", "👍👍👍👍".truncate_bytes(5)
+  #   assert_equal "👍", "👍👍👍👍".truncate_bytes(5, omission: nil)
+  #   assert_equal "👍 ", "👍👍👍👍".truncate_bytes(5, omission: " ")
+  #   assert_equal "🖖", "👍👍👍👍".truncate_bytes(5, omission: "🖖")
+  #
+  #   assert_equal "…", "👍👍👍👍".truncate_bytes(4)
+  #   assert_equal "👍", "👍👍👍👍".truncate_bytes(4, omission: nil)
+  #   assert_equal " ", "👍👍👍👍".truncate_bytes(4, omission: " ")
+  #   assert_equal "🖖", "👍👍👍👍".truncate_bytes(4, omission: "🖖")
+  #
+  #   assert_raise ArgumentError do
+  #     "👍👍👍👍".truncate_bytes(3, omission: "🖖")
+  #   end
+  # end
+  #
+  # def test_truncates_bytes_preserves_grapheme_clusters
+  #   assert_equal "a ", "a ❤️ b".truncate_bytes(2, omission: nil)
+  #   assert_equal "a ", "a ❤️ b".truncate_bytes(3, omission: nil)
+  #   assert_equal "a ", "a ❤️ b".truncate_bytes(7, omission: nil)
+  #   assert_equal "a ❤️", "a ❤️ b".truncate_bytes(8, omission: nil)
+  #
+  #   assert_equal "a ", "a 👩‍❤️‍👩".truncate_bytes(13, omission: nil)
+  #   assert_equal "", "👩‍❤️‍👩".truncate_bytes(13, omission: nil)
+  # end
+  #
   # def test_truncate_words
   #   assert_equal "Hello Big World!", "Hello Big World!".truncate_words(3)
   #   assert_equal "Hello Big...", "Hello Big World!".truncate_words(2)
@@ -316,8 +378,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
   # end
 
   # def test_truncate_multibyte
-  #   assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".dup.force_encoding(Encoding::UTF_8),
-  #     "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".dup.force_encoding(Encoding::UTF_8).truncate(10)
+  #   assert_equal (+"\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...").force_encoding(Encoding::UTF_8),
+  #     (+"\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244").force_encoding(Encoding::UTF_8).truncate(10)
   # end
 
   # def test_truncate_should_not_be_html_safe


### PR DESCRIPTION
The String#truncate method as implemented in the regular ActiveSupport master branch.
This includes the tests, did not run them locally. Manual testing did confirm that the truncate implementation works in Opal.
The `test_truncate_multibyte` test is commented out as it fails to pass, probably because how Opal handles Strings in JS. Not because the truncate implementation is faulty.